### PR TITLE
Using new Service object instead of deprecated execution_path

### DIFF
--- a/.github/workflows/demo-test.yml
+++ b/.github/workflows/demo-test.yml
@@ -1,6 +1,7 @@
 name: demo-test
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
   push:

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ from selenium.webdriver.common.by import By
 
 def handler(event=None, context=None):
     options = webdriver.ChromeOptions()
+    service = webdriver.ChromeService("/opt/chromedriver")
+
     options.binary_location = '/opt/chrome/chrome'
     options.add_argument('--headless')
     options.add_argument('--no-sandbox')
@@ -18,7 +20,8 @@ def handler(event=None, context=None):
     options.add_argument(f"--data-path={mkdtemp()}")
     options.add_argument(f"--disk-cache-dir={mkdtemp()}")
     options.add_argument("--remote-debugging-port=9222")
-    chrome = webdriver.Chrome("/opt/chromedriver",
-                              options=options)
+
+    chrome = webdriver.Chrome(options=options, service=service)
     chrome.get("https://example.com/")
+
     return chrome.find_element(by=By.XPATH, value="//html").text


### PR DESCRIPTION
In selenium 4.9.1 which this repo is using at the moment, a message pops up about execution_path being deprecated: `DeprecationWarning: executable_path has been deprecated, please pass in a Service object`

In newer versions of selenium this code doesn't work at all so it should be changed to using the new syntax